### PR TITLE
Make Python2 -> Python3 switch safer

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,13 @@ environment and clone the git repository.
 
 #### Switching default Python interpreter from Python 2.x to 3.x
 
-Issue the following in the command line of c9:
+We need to tell our command line to use python3 as the default, so we'll create
+an alias in our bash profile, then update the current terminal with the new
+setting. Issue the following in the command line of c9:
 
 ```
 $ echo "alias python=python3" >> ~/.bashrc
+$ source ~/.bashrc
 ```
 
 Then check to make sure it worked:

--- a/README.md
+++ b/README.md
@@ -22,23 +22,19 @@ environment and clone the git repository.
 
 ### Setting Up Your Environment.
 
-#### Switching from Python 2 to 3
+#### Switching default Python interpreter from Python 2.x to 3.x
 
-At the command line in
-cloud9, first delete the `python` alias, then create a new one to `python3`.
+Issue the following in the command line of c9:
 
 ```
-$ sudo ln -sfn /usr/bin/python3 /usr/bin/python
+$ echo "alias python=python3" >> ~/.bashrc
 ```
-Alternatively, if that didn't work:
-```
-$ sudo rm /usr/bin/python
-$ sudo ln -s /usr/bin/python3 /usr/bin/python
-```
+
 Then check to make sure it worked:
+
 ```
 $ python --version
-Python 3.4.3
+Python 3.x.x
 ```
 
 #### Getting the Newest Django


### PR DESCRIPTION
Adding a Bash alias is a safer way to change the default python interpreter as it will not break other programs relying upon 2.x.  Recommend testing in your dev environment before pulling.
